### PR TITLE
Fix Vagrantfile for modern Vagrant

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,13 +2,13 @@
 # vi: set ft=ruby :
 
 Vagrant.configure("2") do |config|
-  config.vm.box = "precise64"
+  config.vm.box = "hashicorp/precise64"
 
   # config.vm.provision :shell, :inline => "apt-get install -y vim curl git"
 
   config.vm.provision :shell, :inline => <<-EOH
     apt-get update
-    apt-get install -y ffmpeg gifsicle imagemagick libmagickwand-dev
+    apt-get install -y ffmpeg gifsicle imagemagick libmagickwand-dev git
     apt-get -y install ruby1.9.1 ruby1.9.1-dev 
     gem install bundler --no-rdoc --no-ri
     cd /vagrant


### PR DESCRIPTION
"vagrant up" failed with "precise64" as the box name; switch to the
hashicorp specific one.

"gem install bundler" also seems to require git to be installed, so add
that to the package list.